### PR TITLE
[ECD-1443] Multiplatform build

### DIFF
--- a/.github/workflows/build_and_release_ecr_image.yml
+++ b/.github/workflows/build_and_release_ecr_image.yml
@@ -57,11 +57,14 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and Push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
@@ -70,7 +73,7 @@ jobs:
             ${{ env.ECR_REPO }}:${{ env.COMMIT_ID }}
             ${{ env.ECR_REPO }}:${{ env.NORMALIZED_BRANCH_NAME }}
             ${{ env.ECR_REPO }}:${{ env.TIMESTAMP }}
-          platforms: linux/arm64
+          platforms: linux/amd64,linux/arm64
 
   release-on-push:
     name: 'Release New Tag On Master Push'


### PR DESCRIPTION
Since we are going to use the image from AWS ECR on the direct https://eatclub.atlassian.net/browse/ECD-1443
we need to have a **multiplatform** build instead of `arm` only.

The image build with this PR (`${{ secrets.CORE_ACCOUNT_ID }}.dkr.ecr.us-west-1.amazonaws.com/mjml-server:ecd-1443-multi-platform-build`) was checked in a PR for direct - https://github.com/eatclub/direct-backend/pull/1506

The open question to the SRE team:
Do we need to change the `docker pull ...` in a `tag-image-with-release-and-latest` job of the Github Action of the repo?