### PR TITLE
[ECD-1443] Multiplatform image build on release

### DIFF
--- a/.github/workflows/build_and_release_ecr_image.yml
+++ b/.github/workflows/build_and_release_ecr_image.yml
@@ -98,7 +98,8 @@ jobs:
 
   tag-image-with-release-and-latest:
     name: 'Tag Image With New Release and latest'
-    needs: [lint-and-test, build-tag-push-image, release-on-push]
+#    needs: [lint-and-test, build-tag-push-image, release-on-push]
+    needs: [lint-and-test, build-tag-push-image]
     runs-on: ubuntu-latest
     env:
       ECR_REPO: "${{ secrets.PROD_AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/mjml-server"
@@ -106,7 +107,6 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Login to core-prod AWS account
-        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.PROD_AWS_ACCOUNT_ID }}:role/github-actions
@@ -120,11 +120,15 @@ jobs:
       - name: Pull Original Image for ARM64
         run: docker pull --platform linux/arm64 $ECR_REPO:$COMMIT_ID
 
+      - name: List all files
+        run: ls -lah
+
       - name: Build, Tag & Push Multi-Platform Image
         run: |
           docker buildx create --use
           docker buildx build --platform linux/amd64,linux/arm64 \
-            --tag $ECR_REPO:latest \
-            --tag $ECR_REPO:${{ needs.release-on-push.outputs.release_version }} \
-            --push .
-          echo "Release version '${{ needs.release-on-push.outputs.release_version }}'"
+#            --tag $ECR_REPO:latest \
+            --tag $ECR_REPO:test \
+            --file ./Dockerfile \
+#            --push .
+          echo "Testing build on release w/o a release =)"

--- a/.github/workflows/build_and_release_ecr_image.yml
+++ b/.github/workflows/build_and_release_ecr_image.yml
@@ -121,7 +121,7 @@ jobs:
         run: docker pull --platform linux/arm64 $ECR_REPO:$COMMIT_ID
 
       - name: List all files
-        run: ls -al
+        run: ls
 
       - name: Build, Tag & Push Multi-Platform Image
         run: |

--- a/.github/workflows/build_and_release_ecr_image.yml
+++ b/.github/workflows/build_and_release_ecr_image.yml
@@ -127,7 +127,8 @@ jobs:
           docker buildx create --use
           docker buildx build --platform linux/amd64,linux/arm64 \
             --tag $ECR_REPO:test \
-            --file ./Dockerfile
+            --file ./Dockerfile \
+            .
           echo "Testing build on release w/o a release =)"
 
       # - name: Build, Tag & Push Multi-Platform Image

--- a/.github/workflows/build_and_release_ecr_image.yml
+++ b/.github/workflows/build_and_release_ecr_image.yml
@@ -127,8 +127,16 @@ jobs:
         run: |
           docker buildx create --use
           docker buildx build --platform linux/amd64,linux/arm64 \
-#            --tag $ECR_REPO:latest \
             --tag $ECR_REPO:test \
-            --file ./Dockerfile \
-#            --push .
+            --file ./Dockerfile
           echo "Testing build on release w/o a release =)"
+
+      # - name: Build, Tag & Push Multi-Platform Image
+      #   run: |
+      #     docker buildx create --use
+      #     docker buildx build --platform linux/amd64,linux/arm64 \
+      #       --tag $ECR_REPO:latest \
+      #       --tag $ECR_REPO:test \
+      #       --file ./Dockerfile \
+      #       --push .
+      #     echo "Testing build on release w/o a release =)"

--- a/.github/workflows/build_and_release_ecr_image.yml
+++ b/.github/workflows/build_and_release_ecr_image.yml
@@ -104,6 +104,9 @@ jobs:
       ECR_REPO: "${{ secrets.PROD_AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/mjml-server"
       COMMIT_ID: ${{ github.sha }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Login to core-prod AWS account
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -120,7 +123,7 @@ jobs:
         run: docker pull --platform linux/arm64 $ECR_REPO:$COMMIT_ID
 
       - name: List all files
-        run: ls -la
+        run: ls
 
       - name: Build, Tag & Push Multi-Platform Image
         run: |

--- a/.github/workflows/build_and_release_ecr_image.yml
+++ b/.github/workflows/build_and_release_ecr_image.yml
@@ -121,7 +121,7 @@ jobs:
         run: docker pull --platform linux/arm64 $ECR_REPO:$COMMIT_ID
 
       - name: List all files
-        run: ls
+        run: ls -la
 
       - name: Build, Tag & Push Multi-Platform Image
         run: |
@@ -129,6 +129,6 @@ jobs:
           docker buildx build --platform linux/amd64,linux/arm64 \
 #            --tag $ECR_REPO:latest \
             --tag $ECR_REPO:test \
-            --file ./Dockerfile \
+            --file ./Dockerfile
 #            --push .
           echo "Testing build on release w/o a release =)"

--- a/.github/workflows/build_and_release_ecr_image.yml
+++ b/.github/workflows/build_and_release_ecr_image.yml
@@ -131,3 +131,4 @@ jobs:
             --tag $ECR_REPO:${{ needs.release-on-push.outputs.release_version }} \
             --push .
           echo "Release version '${{ needs.release-on-push.outputs.release_version }}'"
+  

--- a/.github/workflows/build_and_release_ecr_image.yml
+++ b/.github/workflows/build_and_release_ecr_image.yml
@@ -131,4 +131,3 @@ jobs:
             --tag $ECR_REPO:${{ needs.release-on-push.outputs.release_version }} \
             --push .
           echo "Release version '${{ needs.release-on-push.outputs.release_version }}'"
-  

--- a/.github/workflows/build_and_release_ecr_image.yml
+++ b/.github/workflows/build_and_release_ecr_image.yml
@@ -98,15 +98,14 @@ jobs:
 
   tag-image-with-release-and-latest:
     name: 'Tag Image With New Release and latest'
-#    needs: [lint-and-test, build-tag-push-image, release-on-push]
     needs: [lint-and-test, build-tag-push-image]
     runs-on: ubuntu-latest
     env:
       ECR_REPO: "${{ secrets.PROD_AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/mjml-server"
       COMMIT_ID: ${{ github.sha }}
-#    if: github.ref == 'refs/heads/master'
     steps:
       - name: Login to core-prod AWS account
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.PROD_AWS_ACCOUNT_ID }}:role/github-actions

--- a/.github/workflows/build_and_release_ecr_image.yml
+++ b/.github/workflows/build_and_release_ecr_image.yml
@@ -98,11 +98,12 @@ jobs:
 
   tag-image-with-release-and-latest:
     name: 'Tag Image With New Release and latest'
-    needs: [lint-and-test, build-tag-push-image]
+    needs: [lint-and-test, build-tag-push-image, release-on-push]
     runs-on: ubuntu-latest
     env:
       ECR_REPO: "${{ secrets.PROD_AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/mjml-server"
       COMMIT_ID: ${{ github.sha }}
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -122,24 +123,11 @@ jobs:
       - name: Pull Original Image for ARM64
         run: docker pull --platform linux/arm64 $ECR_REPO:$COMMIT_ID
 
-      - name: List all files
-        run: ls
-
       - name: Build, Tag & Push Multi-Platform Image
         run: |
           docker buildx create --use
           docker buildx build --platform linux/amd64,linux/arm64 \
-            --tag $ECR_REPO:test \
-            --file ./Dockerfile \
-            .
-          echo "Testing build on release w/o a release =)"
-
-      # - name: Build, Tag & Push Multi-Platform Image
-      #   run: |
-      #     docker buildx create --use
-      #     docker buildx build --platform linux/amd64,linux/arm64 \
-      #       --tag $ECR_REPO:latest \
-      #       --tag $ECR_REPO:test \
-      #       --file ./Dockerfile \
-      #       --push .
-      #     echo "Testing build on release w/o a release =)"
+            --tag $ECR_REPO:latest \
+            --tag $ECR_REPO:${{ needs.release-on-push.outputs.release_version }} \
+            --push .
+          echo "Release version '${{ needs.release-on-push.outputs.release_version }}'"

--- a/.github/workflows/build_and_release_ecr_image.yml
+++ b/.github/workflows/build_and_release_ecr_image.yml
@@ -121,14 +121,12 @@ jobs:
         run: docker pull --platform linux/arm64 $ECR_REPO:$COMMIT_ID
 
       - name: List all files
-        run: ls -la
+        run: ls -al
 
       - name: Build, Tag & Push Multi-Platform Image
         run: |
           docker buildx create --use
           docker buildx build --platform linux/amd64,linux/arm64 \
-#            --tag $ECR_REPO:latest \
             --tag $ECR_REPO:test \
             --file ./Dockerfile
-#            --push .
           echo "Testing build on release w/o a release =)"

--- a/.github/workflows/build_and_release_ecr_image.yml
+++ b/.github/workflows/build_and_release_ecr_image.yml
@@ -121,7 +121,7 @@ jobs:
         run: docker pull --platform linux/arm64 $ECR_REPO:$COMMIT_ID
 
       - name: List all files
-        run: ls -lah
+        run: ls -al
 
       - name: Build, Tag & Push Multi-Platform Image
         run: |

--- a/.github/workflows/build_and_release_ecr_image.yml
+++ b/.github/workflows/build_and_release_ecr_image.yml
@@ -104,7 +104,7 @@ jobs:
     env:
       ECR_REPO: "${{ secrets.PROD_AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/mjml-server"
       COMMIT_ID: ${{ github.sha }}
-    if: github.ref == 'refs/heads/master'
+#    if: github.ref == 'refs/heads/master'
     steps:
       - name: Login to core-prod AWS account
         with:


### PR DESCRIPTION
We, together with @tommytaiwo did some debugging here for the failing final step to build and push the image to ECR.
Looks like we just missing a `.Dockerfile` so this PR adds a `checkout` step which should fix the issue.